### PR TITLE
Resizing script on its own, model import in localPredictions folder

### DIFF
--- a/localPredictions/importModels.R
+++ b/localPredictions/importModels.R
@@ -1,0 +1,10 @@
+
+# We need to transfer every vascular plants model from BioDivMapping over to here
+hotspotsDir <- "../BioDivMapping/data/run_2024-10-11/modelOutputs"
+
+# Get every file in there with vascular plants involved
+dirsWithModel <- list.files(hotspotsDir, recursive = TRUE, pattern = "*richnessModel.rds", full.names = TRUE)
+dirsWithModelPlants <- dirsWithModel[grep("vascularPlants", dirsWithModel)]
+newNames <- gsub("vascularPlants", "", gsub("/", "", gsub(hotspotsDir, "", dirsWithModelPlants)))
+
+file.copy(dirsWithModelPlants, paste0("localPredictions/data/modelObjects/", newNames))

--- a/modelResizing.R
+++ b/modelResizing.R
@@ -6,17 +6,18 @@ source("functions/reset_environments.R")
 
 # Get every file in there with vascular plants involved
 dirsWithModel <- list.files(hotspotsDir, recursive = TRUE, pattern = "*richnessModel.rds", full.names = TRUE)
-dirsWithModelPlants <- dirsWithModel[grep("vascularPlants", dirsWithModel)]
+taxaWithModels <- gsub(paste0(hotspotsDir, "/"), "", unique(gsub('[[:digit:]]+', '', sub("\\/.*", "", taxaWithModels))))
 
 
-for (i in seq_along(dirsWithModelPlants)[92]) {
-  modelName <- dirsWithModelPlants[[i]]
-  richnessModel <- readRDS(modelName)
-  #obj_size(richnessModel)
-  reducedModel <- reset_environments(richnessModel)
-  rm("richnessModel")
-  fileName <- paste0("localPredictions/data/modelObjects/reducedModel", i, ".rds")
-  saveRDS(reducedModel, fileName)
-  if (i %% 10 == 0) cat(i, " models complete")
+for (taxa in taxaWithModels) {
+  dirsWithModelTaxa <- dirsWithModel[grep(taxa, dirsWithModel)]
+  for (i in seq_along(dirsWithModelTaxa)) {
+    modelName <- dirsWithModelTaxa[[i]]
+    richnessModel <- readRDS(modelName)
+    #obj_size(richnessModel)
+    reducedModel <- reset_environments(richnessModel)
+    saveRDS(reducedModel, modelName)
+    if (i %% 10 == 0) cat(i, " models complete")
+  }
 }
-
+  


### PR DESCRIPTION
# Why have changes been made?

We want to be able to resize all models, not just the ones used for the local predictions. Do this here instead of in the Hotspots repo.

# What changes have been made?

- modelResizing.R - This script now resizes all scripts at once (takes a long time though)
- localPredictions/importModels.R - New script to improt models specifically used to run predictions for vascular plants